### PR TITLE
Switch only `const` declaration to `var`

### DIFF
--- a/worker.js
+++ b/worker.js
@@ -55,7 +55,7 @@ function createChannel () {
   }
 
   function replyToClient (clientId) {
-    const args = atoa(arguments)
+    var args = atoa(arguments)
     return self.clients.matchAll().then(findClientById(clientId)).then(reply);
     function reply (client) {
       args[0] = client;


### PR DESCRIPTION
Current Swivel build does not go through any transpiling step, which is why variables are declared using `var`.

Except at this one place in the `replyToClient` function (introduced by d8f6613), where the use of `const` causes a syntax error in non-supporting browsers.

This PR switches the declaration to `var` to fix these errors.