### PR TITLE
Allow universal require/import of swivel module

### DIFF
--- a/swivel.js
+++ b/swivel.js
@@ -4,9 +4,9 @@ var page = require('./page');
 var worker = require('./worker');
 var api;
 
-if ('serviceWorker' in navigator) {
+if (typeof navigator !== 'undefined' && 'serviceWorker' in navigator) {
   api = page();
-} else if ('clients' in self) {
+} else if (typeof self !== 'undefined' && 'clients' in self) {
   api = worker();
 } else {
   api = {


### PR DESCRIPTION
It is sometime helpful to `require`/`import` Swivel in universal builds. However the current version does not allow it, as it assumes that module is imported in a browser context, and throws an error when attempting to access the `navigator` global.

This patch adds type-checking for browser-specific globals, allowing universal require/import of Swivel.